### PR TITLE
corrected PYTHONPATH in WRF4G wrapper

### DIFF
--- a/drm4g/conf/wrf4g_wrapper.sh
+++ b/drm4g/conf/wrf4g_wrapper.sh
@@ -87,7 +87,7 @@ execution(){
 
     export PATH=.:./bin:$PATH
 
-    export PYTHONPATH=./lib/python*/:./lib/python*/site-packages:$PYTHONPATH
+    export PYTHONPATH=./lib/python/:./lib/python/site-packages:$PYTHONPATH
 
     export LD_LIBRARY_PATH=./lib:./lib64:$LD_LIBRARY_PATH
 

--- a/drm4g/conf/wrf4g_wrapper.sh
+++ b/drm4g/conf/wrf4g_wrapper.sh
@@ -87,7 +87,7 @@ execution(){
 
     export PATH=.:./bin:$PATH
 
-    export PYTHONPATH=./lib/python/:./lib/python/site-packages:$PYTHONPATH
+    export PYTHONPATH=./lib/python*/:./lib/python*/site-packages:$PYTHONPATH
 
     export LD_LIBRARY_PATH=./lib:./lib64:$LD_LIBRARY_PATH
 

--- a/drm4g/core/tm_mad.py
+++ b/drm4g/core/tm_mad.py
@@ -151,8 +151,11 @@ class GwTmMad (object):
         OPERATION, JID, TID, EXE_MODE, SRC_URL, DST_URL = args.split()
         try:
             com = self._update_com( urlparse( SRC_URL ).host )
-            com.rmDirectory( SRC_URL )
-            out = 'RMDIR %s - SUCCESS -' % ( JID )
+            if not self.checkOutLock(SRC_URL):
+                com.rmDirectory(SRC_URL)
+                out = 'RMDIR %s - SUCCESS -' % (JID)
+            else:
+                out = 'RMDIR %s ignored because lock exists - SUCCESS -' % (JID)
         except Exception as err :
             out = 'RMDIR %s - FAILURE %s' % ( JID , str( err ) )
         self.message.stdout( out )


### PR DESCRIPTION
BASH does not expand the asterisk before defining the environmental variable, so with the old line wrong paths with asterisk are added to PYTHONPATH